### PR TITLE
Remove feature(conservative_impl_trait) to get closer to stable rust

### DIFF
--- a/osc_address_derive/src/lib.rs
+++ b/osc_address_derive/src/lib.rs
@@ -164,7 +164,6 @@
 
 // quote/syn crates require high macro expandion recursion limits
 #![recursion_limit="128"]
-#![feature(conservative_impl_trait)]
 extern crate proc_macro;
 #[macro_use]
 extern crate quote;


### PR DESCRIPTION
This seems to be the last thing in this crate stopping it from running on stable rust. There's an upstream problem with `serde_osc`, though, which uses `feature(try_from)`, which could probably also be fixed pretty easily.